### PR TITLE
modem-manager-autosetup: Fix jq filter for apn without 'type' attribute

### DIFF
--- a/utils/modem-manager-autosetup/files/autosetup.sh
+++ b/utils/modem-manager-autosetup/files/autosetup.sh
@@ -7,7 +7,7 @@ get_settings() {
     [ -n "$1" ] || return
     local mcc="$(echo "$1" | head -c 3)"
     local mnc="$(echo "$1" | tail -c +4)"
-    local info="$(jq '.apns.apn| [ .[] | select(.mcc == "'"$mcc"'" and .mnc == "'"$mnc"'" and (.type | contains("default"))) ][0]' < /usr/share/modem-manager-autosetup/apns-conf.json)"
+    local info="$(jq '.apns.apn| [ .[] | select(.mcc == "'"$mcc"'" and .mnc == "'"$mnc"'" and has("type") and (.type | contains("default"))) ][0]' < /usr/share/modem-manager-autosetup/apns-conf.json)"
     [ -n "$info" ] || info="$(jq '.apns.apn| [ .[] | select(.mcc == "'"$mcc"'" and .mnc == "'"$mnc"'") ][0]' < /usr/share/modem-manager-autosetup/apns-conf.json)"
     if [ -n "$info" ] &&  [ "$info" != null ]; then
         APN="$(echo "$info" | jq -r .apn)"


### PR DESCRIPTION
The initial jq filter used to extract the APN info from `apns-conf.json` fails with:

``` text
jq: error (...): null (null) and string ("default") cannot have their containment checked
```
when one of the apn objects selected by mcc/mnc doesn't have a `type` attribute (as is the case for mcc=262, mnc=07). As a result, otherwise matching APN objects will not be considered.

This commit fixes the jq filter by checking for the presence of the `type` attribute.

This PR fixes [gitlab.nic.cz issue 951](https://gitlab.nic.cz/turris/os/packages/-/issues/951).