### PR TITLE
modem-manager-autosetup: Use optional mvno_match_data for APN selection

### DIFF
--- a/utils/modem-manager-autosetup/files/autosetup.sh
+++ b/utils/modem-manager-autosetup/files/autosetup.sh
@@ -7,7 +7,7 @@ get_settings() {
     [ -n "$1" ] || return
     local mcc="$(echo "$1" | head -c 3)"
     local mnc="$(echo "$1" | tail -c +4)"
-    local info="$(jq '.apns.apn| [ .[] | select(.mcc == "'"$mcc"'" and .mnc == "'"$mnc"'" and (.type | contains("default"))) ][0]' < /usr/share/modem-manager-autosetup/apns-conf.json)"
+    local info="$(jq '.apns.apn| [ .[] | select(.mcc == "'"$mcc"'" and .mnc == "'"$mnc"'" and has("type") and (.type | contains("default"))) ][0]' < /usr/share/modem-manager-autosetup/apns-conf.json)"
     [ -n "$info" ] || info="$(jq '.apns.apn| [ .[] | select(.mcc == "'"$mcc"'" and .mnc == "'"$mnc"'") ][0]' < /usr/share/modem-manager-autosetup/apns-conf.json)"
     if [ -n "$info" ] &&  [ "$info" != null ]; then
         APN="$(echo "$info" | jq -r .apn)"

--- a/utils/modem-manager-autosetup/files/autosetup.sh
+++ b/utils/modem-manager-autosetup/files/autosetup.sh
@@ -7,9 +7,15 @@ get_settings() {
     [ -n "$1" ] || return
     local mcc="$(echo "$1" | head -c 3)"
     local mnc="$(echo "$1" | tail -c +4)"
-    local info="$(jq '.apns.apn| [ .[] | select(.mcc == "'"$mcc"'" and .mnc == "'"$mnc"'" and has("type") and (.type | contains("default"))) ][0]' < /usr/share/modem-manager-autosetup/apns-conf.json)"
-    [ -n "$info" ] || info="$(jq '.apns.apn| [ .[] | select(.mcc == "'"$mcc"'" and .mnc == "'"$mnc"'") ][0]' < /usr/share/modem-manager-autosetup/apns-conf.json)"
-    if [ -n "$info" ] &&  [ "$info" != null ]; then
+    local imsi="$2"
+    local info="$(jq '.apns.apn[] | select(.mcc == "'"$mcc"'" and .mnc == "'"$mnc"'" and has("type") and (.type | contains("default")))' < /usr/share/modem-manager-autosetup/apns-conf.json)"
+    [ -n "$info" ] || info="$(jq '.apns.apn[] | select(.mcc == "'"$mcc"'" and .mnc == "'"$mnc"'")' < /usr/share/modem-manager-autosetup/apns-conf.json)"
+    if [ -n "$info" ] && [ -n "$imsi" ]; then
+        local tmp="$(echo "$info" | jq 'select(.mvno_match_data? and .mvno_type? == "imsi") | select(.mvno_match_data as $mvno | "'"$imsi"'" | startswith($mvno))')"
+        [ -z "$tmp" ] || info="$tmp"
+    fi
+    if [ -n "$info" ]; then
+        info="$(echo "$info" | jq -s '.[0]')"
         APN="$(echo "$info" | jq -r .apn)"
         USER="$(echo "$info" | jq -r .user)"
         PASSWORD="$(echo "$info" | jq -r .password)"
@@ -18,6 +24,10 @@ get_settings() {
 
 get_operator_info() {
     mmcli -i 0 -K | sed -n 's|^sim.properties.operator-code[[:blank:]]*:[[:blank:]]*||p'
+}
+
+get_imsi() {
+    mmcli -i 0 -K | sed -n 's|^sim.properties.imsi[[:blank:]]*:[[:blank:]]*||p'
 }
 
 disable_and_exit() {
@@ -69,7 +79,8 @@ EOF
 
 check_config
 OPERATOR="$(get_operator_info)"
+IMSI="$(get_imsi)"
 [ -n "$OPERATOR" ] || exit 0
-get_settings "$OPERATOR"
+get_settings "$OPERATOR" "$IMSI"
 [ -n "$APN" ] || exit 0
 set_configs


### PR DESCRIPTION
Note: This PR builds on #2.
 
In case that there are multiple APN definitions for the given combination of `mnc`, `nmc` (and `type`) and an `mvno_match_data` attribute of type `imsi` exists, the `mvno_match_data` can be used to select the correct APN from a set of otherwise equivalent ones.

This PR adds an additional step which uses `mvno_match_data` to improve the APN selection process.

This addresses the 2nd part of [gitlab.nic.cz issue 951](https://gitlab.nic.cz/turris/os/packages/-/issues/951).