### PR TITLE
Suricata: allow building for Turris 1.x, cleanup

### DIFF
--- a/net/suricata-bin/Makefile
+++ b/net/suricata-bin/Makefile
@@ -52,6 +52,7 @@ define Package/suricata-bin
   TITLE:=Network IDS, IPS and NSM engine
   URL:=https://suricata-ids.org/
   DEPENDS:= \
+	$(RUST_ARCH_DEPENDS) \
 	+libpcre2 \
 	+libyaml \
 	+jansson \

--- a/net/suricata-bin/Makefile
+++ b/net/suricata-bin/Makefile
@@ -56,9 +56,6 @@ define Package/suricata-bin
 	+libpcre2 \
 	+libyaml \
 	+jansson \
-	+libmagic \
-	+libpthread \
-	+librt \
 	+libpcap \
 	+libcap-ng \
 	+libnetfilter-queue \

--- a/net/suricata-bin/Makefile
+++ b/net/suricata-bin/Makefile
@@ -46,6 +46,9 @@ CONFIGURE_ARGS+= \
 # with stack protection enabled by default, which doesn't work with musl on 32-bit arches
 TARGET_CFLAGS+=-fno-stack-protector
 
+# Add atomic library for 64-bit atomic operations on 32-bit PowerPC
+TARGET_LDFLAGS+=-latomic
+
 define Package/suricata-bin
   SECTION:=net
   CATEGORY:=Network
@@ -64,6 +67,7 @@ define Package/suricata-bin
 	+libnfnetlink \
 	+iptables-mod-conntrack-extra \
 	+libnet-1.2.x \
+	+libatomic \
 	+nspr \
 	+libnss \
 	+liblz4 \

--- a/net/suricata-bin/Makefile
+++ b/net/suricata-bin/Makefile
@@ -67,6 +67,7 @@ define Package/suricata-bin
 	+nspr \
 	+libnss \
 	+liblz4 \
+	+zlib \
 	+PACKAGE_libunwind:libunwind
 endef
 

--- a/net/suricata-bin/Makefile
+++ b/net/suricata-bin/Makefile
@@ -60,7 +60,6 @@ define Package/suricata-bin
 	+librt \
 	+libpcap \
 	+libcap-ng \
-	$(LUAJIT_DEP) \
 	+libnetfilter-queue \
 	+iptables-mod-nfqueue \
 	+libnetfilter-log \

--- a/net/suricata-bin/Makefile
+++ b/net/suricata-bin/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=suricata-bin
-PKG_VERSION:=8.0.0
+PKG_VERSION:=8.0.1
 PKG_RELEASE=$(AUTORELEASE)
 
 PKG_SOURCE:=suricata-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openinfosecfoundation.org/download/
-PKG_HASH:=51f36ef492cbee8779d6018e4f18b98a08e677525851251279c1f851654f451f
+PKG_HASH:=bd868f41717e5431cdda3a99386810257aafdbe2dbcbb58d07fb8476a03358a5
 
 PKG_MAINTAINER:=CZ.NIC <packaging@turris.cz>
 PKG_LICENSE:=GPL-2.0

--- a/net/suricata-bin/Makefile
+++ b/net/suricata-bin/Makefile
@@ -31,9 +31,6 @@ PKG_SSP:=0
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/rust/rust-values.mk
 
-TARGET_CFLAGS += \
-        -fcommon
-
 CONFIGURE_ARGS+= \
 	--enable-nflog \
 	--enable-nfqueue \

--- a/net/suricata-bin/Makefile
+++ b/net/suricata-bin/Makefile
@@ -26,6 +26,7 @@ PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
 PKG_BUILD_DEPENDS:=rust/host
 PKG_BUILD_PARALLEL:=1
+PKG_SSP:=0
 
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/rust/rust-values.mk
@@ -42,6 +43,11 @@ CONFIGURE_ARGS+= \
 	--disable-python \
 	--host=$(RUSTC_TARGET_ARCH) \
 	--enable-debug # for more log levels
+
+# Disable stack protector to avoid __stack_chk_fail_local errors on musl/PowerPC
+# This is needed because Rust's cc crate compiles vendored C code (like libz-sys)
+# with stack protection enabled by default, which doesn't work with musl on 32-bit arches
+TARGET_CFLAGS+=-fno-stack-protector
 
 define Package/suricata-bin
   SECTION:=net

--- a/net/suricata-bin/Makefile
+++ b/net/suricata-bin/Makefile
@@ -66,8 +66,8 @@ define Package/suricata-bin
 	+libnet-1.2.x \
 	+nspr \
 	+libnss \
-  	+liblz4 \
-	+libunwind
+	+liblz4 \
+	+PACKAGE_libunwind:libunwind
 endef
 
 define Package/suricata-rules


### PR DESCRIPTION
This was somehow missed during the review while updating Suricata to newer version - https://gitlab.nic.cz/turris/os/packages/-/merge_requests/1296 or it was not tested by reviewer. For more than 2 months, Suricata together with the pakon package  is not available for Turris 1.x routers.

While it might look like I was trying to create as many commits as possible, that wasn't my goal. I was trying to break things down to make them understandable, clear, and traceable in the Git history for better future reference and easier "time travel" rather than creating one large commit where no one would know what was changed, why, or how.

I tested it by using minimal build locally and it is run tested on Turris 1.1 router. 

Reported in https://forum.turris.cz/t/turris-os-9-0-is-in-rc/22087/30?u=pepe