### PR TITLE
sentinel-proxy: avoid deref symlinks when installing .so

### DIFF
--- a/collect/sentinel/sentinel-proxy/Makefile
+++ b/collect/sentinel/sentinel-proxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sentinel-proxy
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.nic.cz/turris/sentinel/proxy.git
@@ -58,7 +58,7 @@ define Package/sentinel-proxy/install
 	$(INSTALL_BIN) ./files/sentinel-status.sh $(1)/usr/bin/sentinel-status
 
 	$(INSTALL_DIR) $(1)/usr/lib/ $(1)/lib/functions/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libsentinel-device-token.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsentinel-device-token.so* $(1)/usr/lib/
 	$(INSTALL_DATA) ./files/sentinel.sh $(1)/lib/functions/sentinel.sh
 
 	$(INSTALL_DIR) $(1)/etc/init.d


### PR DESCRIPTION
Before:
```bash
root@turris:~# ll /usr/lib/libsentinel-device-token.so*
-rw-r--r--    1 root     root         65536 May  5 10:28 /usr/lib/libsentinel-device-token.so
-rw-r--r--    1 root     root         65536 May  5 10:28 /usr/lib/libsentinel-device-token.so.1
-rw-r--r--    1 root     root         65536 May  5 10:28 /usr/lib/libsentinel-device-token.so.1.0.0
```

After (compile tested for Turris MOX:
```bash
# tar -Oxzf bin/packages/aarch64_cortex-a53/turrispackages/sentinel-proxy_2.2.0-r1_aarch64_cortex-a53.ipk ./data.tar.gz | tar -tzvf -
lrwxrwxrwx  0 0      0           0 Sep  1  2025 ./usr/lib/libsentinel-device-token.so -> libsentinel-device-token.so.1.0.0
lrwxrwxrwx  0 0      0           0 Sep  1  2025 ./usr/lib/libsentinel-device-token.so.1 -> libsentinel-device-token.so.1.0.0
-rwxr-xr-x  0 0      0       65539 Sep  1  2025 ./usr/lib/libsentinel-device-token.so.1.0.0
```

This is upstream related change which happened in OpenWrt a while ago
Reference:
- https://github.com/openwrt/packages/pull/29415

I am going to ping all Turris members who contributed to this repository, as all of my pull requests ARE BEING IGNORED despite multiple pings here, on the forum, and elsewhere. I don't have any other choice. Sorry!
CC: @tmacholda , @Zatharalex , @miska , @ljelinek-cznic , @muzikr 