### PR TITLE
suricata-bin: apply CARGO_PKG_CONFIG_VARS to the Rust build

### DIFF
--- a/net/suricata-bin/Makefile
+++ b/net/suricata-bin/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=suricata-bin
 PKG_VERSION:=8.0.1
-PKG_RELEASE=9
+PKG_RELEASE=10
 
 PKG_SOURCE:=suricata-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openinfosecfoundation.org/download/
@@ -48,6 +48,15 @@ TARGET_CFLAGS+=-fno-stack-protector
 
 # Add atomic library for 64-bit atomic operations on 32-bit PowerPC
 TARGET_LDFLAGS+=-latomic
+
+# Suricata drives its own cargo invocation from its autotools build, so unlike
+# rust-package.mk based packages it never picks up CARGO_PKG_CONFIG_VARS, and
+# its Rust half is built without the Rust build flags, target compiler settings
+# and target linker used by the rest of the OpenWrt build. On soft-float
+# targets that makes suricata abort at startup while parsing request-body-limit
+# from its own default configuration.
+MAKE_VARS+=$(CARGO_PKG_CONFIG_VARS)
+CONFIGURE_VARS+=$(CARGO_PKG_CONFIG_VARS)
 
 define Package/suricata-bin
   SECTION:=net


### PR DESCRIPTION
suricata-bin includes rust-values.mk but never applies CARGO_PKG_CONFIG_VARS,
so suricata's cargo invocation did not receive the Rust build settings provided
by OpenWrt.

On mpc85xx/p2020 (Turris 1.x, powerpc_8548, soft-float) this made suricata
8.0.1 die at startup parsing its own default config, which also took pakon down
with it - no suricata means nothing reaches /var/run/pakon.sock, so
`pakon-show` reported "no records to show".

## Testing

Built for mpc85xx/p2020 and installed on a Turris 1.x:

- before: `Error: app-layer-htp: Error parsing request-body-limit from conf
  file - 100kb.  Killing engine` (and the same for a plain `102400`)
- after: `Notice: suricata: Configuration provided was successfully loaded`

With suricata running, pakon collects again: 23 completed and 140 in-flight
flows in /var/lib/pakon.db within minutes, and `pakon-show` renders the
timeline including TLS SNI hostnames.

Verified in the built binary that the linked `__gtdf2` is the soft-float
libgcc one operating on GPR pairs.

## Note for reviewers

This changes the Rust build on every architecture, not only powerpc -
RUSTFLAGS, CARGO_BUILD_TARGET, TARGET_CC, TARGET_CFLAGS and the target linker
now reach cargo. The CARGO_PROFILE_RELEASE_* settings are inert here because
--enable-debug makes suricata build its Rust in the debug profile.
